### PR TITLE
fix: Background image position shift on todo addition

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@
 body{
   background-image: url(gradient\ image.png);
   background-position: center;
+  background-attachment: fixed;
   background-size: 70%; 
   width: 100vw;
   height: 100vh;


### PR DESCRIPTION
This line allows us to avoid the background image position shift on todo's addition and deletion by fixing its position